### PR TITLE
FTW dependency management

### DIFF
--- a/logstash-input-couchdb_changes.gemspec
+++ b/logstash-input-couchdb_changes.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-couchdb_changes'
-  s.version         = '0.1.1'
+  s.version         = '0.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This input captures the _changes stream from a CouchDB instance"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program" 
@@ -22,10 +22,9 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency 'logstash', '>= 1.4.0', '< 2.0.0'
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'ftw', '>= 0.0.41'
   s.add_runtime_dependency 'json'
 
-  s.add_development_dependency 'ftw', '>= 0.0.41'
+  s.add_development_dependency 'ftw', '~> 0.0.42'
   s.add_development_dependency 'logstash-devutils', '>= 0.0.6'
   s.add_development_dependency 'logstash-output-elasticsearch'
 


### PR DESCRIPTION
This enables and simplify the ftw dependency gathering from ftw, polling the last minor update every time. This simplify later on our test workflow.