### PR TITLE
Fix #8 Authentication Broken

### DIFF
--- a/logstash-input-couchdb_changes.gemspec
+++ b/logstash-input-couchdb_changes.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-couchdb_changes'
-  s.version         = '0.1.3'
+  s.version         = '0.1.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This input captures the _changes stream from a CouchDB instance"
-  s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program" 
+  s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elasticsearch"]
   s.email           = 'info@elasticsearch.com'
   s.homepage        = "http://www.elasticsearch.org/guide/en/logstash/current/index.html"
@@ -29,4 +29,3 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-output-elasticsearch'
 
 end
-


### PR DESCRIPTION
Implementation was not correct and its test was returning a false
positive.

A couchdb db with no members in it is public. The test was missing the important step of 
adding a member to the database to get an enviroment that requires authentication.

The implementation was performing the authentication using the [URI::HTTP](http://ruby-doc.org/stdlib-2.0.0/libdoc/uri/rdoc/URI/HTTP.html#method-c-build-label-Description) 'build' method
The documentation signals the problem of using it:

 ```
   Currently, if passed userinfo components this method generates
   invalid HTTP URIs as per RFC 1738.
   ```

This PR uses the suggested basic authentication method in [Net::HTTP](http://ruby-doc.org/stdlib-2.2.1/libdoc/net/http/rdoc/Net/HTTP.html#class-Net::HTTP-label-Basic+Authentication)