### PR TITLE
fail fast on permission denied accessing the sequence file

### DIFF
--- a/lib/logstash/inputs/couchdb_changes.rb
+++ b/lib/logstash/inputs/couchdb_changes.rb
@@ -112,7 +112,16 @@ class LogStash::Inputs::CouchDBChanges < LogStash::Inputs::Base
 
     @scheme = @secure ? 'https' : 'http'
 
-    @sequence = @initial_sequence ? @initial_sequence : @sequencedb.read
+    if !@initial_sequence.nil?
+      @logger.info("initial_sequence is set, writing to filesystem ...",
+                   :initial_sequence => @initial_sequence, :sequence_path => @sequence_path)
+      @sequencedb.write(@initial_sequence)
+      @sequence = @initial_sequence
+    else
+      @logger.info("No initial_sequence set, reading from filesystem ...",
+                   :sequence_path => @sequence_path)
+      @sequence = @sequencedb.read
+    end
 
   end
 


### PR DESCRIPTION
if the sequence file cannot be read or written
we should fail before entering the loop processing changes