### PR TITLE
introduced new config 'keep_id' 

### DIFF
--- a/lib/logstash/inputs/couchdb_changes.rb
+++ b/lib/logstash/inputs/couchdb_changes.rb
@@ -64,6 +64,10 @@ class LogStash::Inputs::CouchDBChanges < LogStash::Inputs::Base
   # and that you will unset this value afterwards.
   config :initial_sequence, :validate => :number
 
+  # Preserve the CouchDB document id "_id" value in the
+  # output.
+  config :keep_id, :validate => :boolean, :default => false
+
   # Preserve the CouchDB document revision "_rev" value in the
   # output.
   config :keep_revision, :validate => :boolean, :default => false
@@ -206,7 +210,7 @@ class LogStash::Inputs::CouchDBChanges < LogStash::Inputs::Base
     else
       hash['doc'] = line['doc']
       hash['@metadata']['action'] = 'update'
-      hash['doc'].delete('_id')
+      hash['doc'].delete('_id') unless @keep_id
       hash['doc_as_upsert'] = true
       hash['doc'].delete('_rev') unless @keep_revision
     end


### PR DESCRIPTION
introduced new config 'keep_id' that allows to keep the '_id' field in the document, 
just like the 'keep_revision' config allows to keep the '_rev' field