### PR TITLE
Fix hard coded delay in error message

### DIFF
--- a/lib/logstash/inputs/couchdb_changes.rb
+++ b/lib/logstash/inputs/couchdb_changes.rb
@@ -169,7 +169,7 @@ class LogStash::Inputs::CouchDBChanges < LogStash::Inputs::Base
         end
       rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED,
         Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
-        @logger.error("Connection problem encountered: Retrying connection in " + @reconnect_delay.to_s + " seconds...", :error => e.to_s)
+        @logger.error("Connection problem encountered: Retrying connection in " + @reconnect_delay.to_s + " seconds...", :error => e.to_s, :host => @host.to_s, :port => @port.to_s, :db => @db)
         retry if reconnect?
       rescue Errno::EBADF => e
         @logger.error("Unable to connect: Bad file descriptor: ", :error => e.to_s)

--- a/lib/logstash/inputs/couchdb_changes.rb
+++ b/lib/logstash/inputs/couchdb_changes.rb
@@ -169,7 +169,7 @@ class LogStash::Inputs::CouchDBChanges < LogStash::Inputs::Base
         end
       rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED,
         Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
-        @logger.error("Connection problem encountered: Retrying connection in 10 seconds...", :error => e.to_s)
+        @logger.error("Connection problem encountered: Retrying connection in " + @reconnect_delay.to_s + " seconds...", :error => e.to_s)
         retry if reconnect?
       rescue Errno::EBADF => e
         @logger.error("Unable to connect: Bad file descriptor: ", :error => e.to_s)


### PR DESCRIPTION
since the delay is configurable from the config 'reconnect_delay', this value should be printed instead of the default hard-coded value '10'