### PR TITLE
Fix direct event field reference error

### DIFF
--- a/lib/logstash/inputs/couchdb_changes.rb
+++ b/lib/logstash/inputs/couchdb_changes.rb
@@ -177,7 +177,7 @@ class LogStash::Inputs::CouchDBChanges < LogStash::Inputs::Base
                   @logger.debug("event", :event => event.to_hash_with_metadata) if @logger.debug?
                   decorate(event)
                   queue << event
-                  @sequence = event['@metadata']['seq']
+                  @sequence = event.get("[@metadata][seq]")
                   @sequencedb.write(@sequence.to_s)
                 end
               end


### PR DESCRIPTION
Logstash 5.0 error:

```
Error: Direct event field references (i.e. event['field']) have been disabled
in favor of using event get and set methods (e.g. event.get('field')). Please
consult the Logstash 5.0 breaking changes documentation for more details
```

https://www.elastic.co/guide/en/logstash/5.0/breaking-changes.html#_ruby_filter_and_custom_plugin_developers