### PR TITLE
Fix asciidoc formatting and bump to v3.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.6
+  - Fixed formatting in doc
+
 ## 3.1.5
   - Docs: Set the default_codec doc attribute.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,11 +26,11 @@ CouchDB http://guide.couchdb.org/draft/notifications.html[_changes] URI.
 Moreover, any "future" changes will automatically be streamed as well making it easy to synchronize
 your CouchDB data with any target destination
 
-### Upsert and delete
+===== Upsert and delete
 You can use event metadata to allow for document deletion.
 All non-delete operations are treated as upserts
 
-### Starting at a Specific Sequence
+===== Starting at a Specific Sequence
 The CouchDB input stores the last sequence number value in location defined by `sequence_path`.
 You can use this fact to start or resume the stream at a particular sequence.
 

--- a/logstash-input-couchdb_changes.gemspec
+++ b/logstash-input-couchdb_changes.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-couchdb_changes'
-  s.version         = '3.1.5'
+  s.version         = '3.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Streams events from CouchDB's `_changes` URI"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Clean up formatting to enable our conversion to asciidoctor. 
