### PR TITLE
Replace File.exists? with File.exist?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.7
+  - Fix: replace deprecated `File.exists?` with `File.exist?` for Ruby 3.4 (JRuby 10) compatibility [#52](https://github.com/logstash-plugins/logstash-input-couchdb_changes/pull/52)
+
 ## 3.1.6
   - Fixed formatting in doc
 

--- a/lib/logstash/inputs/couchdb_changes.rb
+++ b/lib/logstash/inputs/couchdb_changes.rb
@@ -136,7 +136,7 @@ class LogStash::Inputs::CouchDBChanges < LogStash::Inputs::Base
       end
 
       def read
-        ::File.exists?(@sequence_path) ? ::File.read(@sequence_path).chomp.strip : 0
+        ::File.exist?(@sequence_path) ? ::File.read(@sequence_path).chomp.strip : 0
       end
 
       def write(sequence = nil)

--- a/logstash-input-couchdb_changes.gemspec
+++ b/logstash-input-couchdb_changes.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-couchdb_changes'
-  s.version         = '3.1.6'
+  s.version         = '3.1.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Streams events from CouchDB's `_changes` URI"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
## Summary
- Replace `File.exists?` with `File.exist?` for Ruby 3.4 compatibility

`File.exists?` was deprecated in Ruby 3.2 and has been removed in Ruby 3.4 (JRuby 10). `File.exist?` has been the preferred method since Ruby 1.0.